### PR TITLE
Add a note that currently base-ami must be set based on region

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This repository contains the CloudFormation template for WSO2 API Manager and re
    }
    ```
 
+Please note that `base-ami` must be set accordingly (`ami-25a97a4a` is for `us-east-2` only).
+
 3. Create WSO2 API Manager AMI by executing the **create-AMI.sh** script as follows:
 
         bash create-AMI.sh -p APIM


### PR DESCRIPTION
Add a note that currently base-ami must be set based on region as no mapping exists, see also https://github.com/docker/machine/issues/287 or https://github.com/awslabs/aws-cloudformation-templates/blob/master/community/services/EFS/efs_with_automount_to_ec2.json for a sample mapping